### PR TITLE
Fix passing selector for the select box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/lib/capybara_select2/helpers.rb
+++ b/lib/capybara_select2/helpers.rb
@@ -22,7 +22,7 @@ module CapybaraSelect2
       container = if container['class'] =~ /select2-container/
         container
       else
-        container.find('.select2-container')
+        container.find(:xpath, '..')find('.select2-container')
       end
 
       select2_version = Utils.detect_select2_version(container)

--- a/lib/capybara_select2/helpers.rb
+++ b/lib/capybara_select2/helpers.rb
@@ -22,7 +22,7 @@ module CapybaraSelect2
       container = if container['class'] =~ /select2-container/
         container
       else
-        container.find(:xpath, '..')find('.select2-container')
+        container.find(:xpath, '..').find('.select2-container')
       end
 
       select2_version = Utils.detect_select2_version(container)

--- a/lib/capybara_select2/helpers.rb
+++ b/lib/capybara_select2/helpers.rb
@@ -10,9 +10,9 @@ module CapybaraSelect2
       Utils.validate_options!(options)
 
       container = if options[:xpath]
-        find(:xpath, options[:xpath])
+        find(:xpath, options[:xpath], visible: :all)
       elsif options[:css]
-        find(:css, options[:css])
+        find(:css, options[:css], visible: :all)
       else
         find("label:not(.select2-offscreen)", text: options[:from])
           .find(:xpath, '..')
@@ -22,7 +22,7 @@ module CapybaraSelect2
       container = if container['class'] =~ /select2-container/
         container
       else
-        container.find(:xpath, '..').find('.select2-container')
+        container.find('.select2-container') rescue container.sibling('.select2-container')
       end
 
       select2_version = Utils.detect_select2_version(container)

--- a/spec/select2_v2_spec.rb
+++ b/spec/select2_v2_spec.rb
@@ -21,6 +21,11 @@ describe CapybaraSelect2 do
           expect(page).to have_css '.select2-container span', text: 'XBox'
         end
 
+        it 'should select an option from select found by direct ID of the select box' do
+          select2 'XBox', css: '#console'
+          expect(page).to have_css '.select2-container span', text: 'XBox'
+        end
+
         it 'should select an option from select found by label' do
           select2 'XBox', from: 'Select game console'
           expect(page).to have_css '.select2-container span', text: 'XBox'
@@ -60,6 +65,11 @@ describe CapybaraSelect2 do
 
         it 'should select an option from select found by label' do
           select2 'Buy Milk', from: 'Things to do'
+          expect(page).to have_css '.select2-search-choice', text: 'Buy Milk'
+        end
+
+        it 'should select an option from select found by direct ID of the select box' do
+          select2 'Buy Milk', css: '#todo'
           expect(page).to have_css '.select2-search-choice', text: 'Buy Milk'
         end
 

--- a/spec/select2_v3_spec.rb
+++ b/spec/select2_v3_spec.rb
@@ -26,6 +26,11 @@ describe CapybaraSelect2 do
           expect(page).to have_css '.select2-chosen', text: 'XBox'
         end
 
+        it 'should select an option from select found by direct ID of the select box' do
+          select2 'XBox', css: '#console'
+          expect(page).to have_css '.select2-chosen', text: 'XBox'
+        end
+
         context 'when searching for an option' do
           before { select2 'Wii', css: '#single', search: true }
 
@@ -58,6 +63,11 @@ describe CapybaraSelect2 do
 
         it 'should select an option from select found by label' do
           select2 'Buy Milk', from: 'Things to do'
+          expect(page).to have_css '.select2-search-choice', text: 'Buy Milk'
+        end
+
+        it 'should select an option from select found by direct ID of the select box' do
+          select2 'Buy Milk', css: '#todo'
           expect(page).to have_css '.select2-search-choice', text: 'Buy Milk'
         end
 

--- a/spec/select2_v4_spec.rb
+++ b/spec/select2_v4_spec.rb
@@ -26,6 +26,11 @@ describe CapybaraSelect2 do
           expect(page).to have_css '.select2-container span', text: 'XBox'
         end
 
+        it 'should select an option from select found by direct ID of the select box' do
+          select2 'XBox', css: '#console'
+          expect(page).to have_css '.select2-container span', text: 'XBox'
+        end
+
         context 'when searching for an option' do
           before { select2 'Wii', css: '#single', search: true }
 
@@ -58,6 +63,11 @@ describe CapybaraSelect2 do
 
         it 'should select an option from select found by label' do
           select2 'Buy Milk', from: 'Things to do'
+          expect(page).to have_css '.select2-selection__choice', text: 'Buy Milk'
+        end
+
+        it 'should select an option from select found by direct ID of the select box' do
+          select2 'Buy Milk', css: '#todo'
           expect(page).to have_css '.select2-selection__choice', text: 'Buy Milk'
         end
 


### PR DESCRIPTION
If directly select box is passed to the select2, we need to look into the parent's context in order to find the container.

Does this make sense?