### PR TITLE
Update README to include MiniTest setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,17 @@ Or install it yourself as:
 
     $ gem install capybara-select-2
 
-[Note] In the projects which use RSpec or Cucumber `select2` helper is available out of the box
+[Note] In the projects which use RSpec or Cucumber, the `select2` helper is available out of the box
+
+### Manual installation with Minitest
+
+In your application_system_test_case.rb
+
+```ruby
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+  include CapybaraSelect2::Helpers
+end
+```
 
 ### Manual installation with Rspec
 


### PR DESCRIPTION
This gem also works with MiniTest, so I thought it would be helpful to update the README with setup instructions.

I also corrected a small grammatical error on line 26, adding a comma and a `the` after `RSpec and Cucumber`. 