### PR TITLE
Require 'capybara_select2/selectors'

### DIFF
--- a/lib/capybara_select2/helpers.rb
+++ b/lib/capybara_select2/helpers.rb
@@ -1,4 +1,5 @@
 require 'capybara_select2/utils'
+require 'capybara_select2/selectors'
 
 module CapybaraSelect2
   module Helpers


### PR DESCRIPTION
When using with Rails 5.2
```
class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
  driven_by :selenium, using: :headless_chrome
  include CapybaraSelect2::Helpers
  ...
end
```
I was getting an error `uninitialized constant CapybaraSelect2::Helpers::Selectors`.  Requiring the selectors fixed my issue.