### PR TITLE
Adding an 'exact_text' option for getting exactly the text you want in ambiguous results

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ select2 'Buy Milk', 'Go to gym', css: '#todo'
 select2 'Buy Milk', from: 'Things to do', search: true, match: :first
 ```
 
+### Search for exact text in the specified node
+```ruby
+select2 'Buy Milk', from: 'Things to do', exact_text: true
+```
+
 ### Check for select2 option on the page
 ```ruby
 expect(page).to have_select2_option('Buy Milk')

--- a/lib/capybara_select2/helpers.rb
+++ b/lib/capybara_select2/helpers.rb
@@ -26,6 +26,7 @@ module CapybaraSelect2
 
         find_options = { text: value }
         find_options[:match] = options[:match] if options[:match]
+        find_options[:exact_text] = options[:exact_text] if options[:exact_text]
         find(:xpath, '//body').find(:css, option_selector, find_options).click
       end
     end

--- a/spec/select2_v2_spec.rb
+++ b/spec/select2_v2_spec.rb
@@ -35,6 +35,11 @@ describe CapybaraSelect2 do
           select2 'PlayStation', css: '#single', search: true, match: :first
           expect(page).to have_css '.select2-container span', text: 'PlayStation 3'
         end
+
+        it 'should select option with exact text from search results' do
+          select2 'PlayStation', css: '#single', exact_text: true
+          expect(page).to have_css '.select2-container span', text: 'PlayStation'
+        end
       end
 
       context 'when searching for an option within a block' do

--- a/spec/select2_v3_spec.rb
+++ b/spec/select2_v3_spec.rb
@@ -33,6 +33,11 @@ describe CapybaraSelect2 do
           select2 'PlayStation', css: '#single', search: true, match: :first
           expect(page).to have_css '.select2-chosen', text: 'PlayStation 3'
         end
+
+        it 'should select option with exact text from search results' do
+          select2 'PlayStation', css: '#single', exact_text: true
+          expect(page).to have_css '.select2-chosen', text: 'PlayStation'
+        end
       end
 
       context 'when searching for an option within a block' do

--- a/spec/select2_v4_spec.rb
+++ b/spec/select2_v4_spec.rb
@@ -33,6 +33,11 @@ describe CapybaraSelect2 do
           select2 'PlayStation', css: '#single', search: true, match: :first
           expect(page).to have_css '.select2-container span', text: 'PlayStation 3'
         end
+
+        it 'should select option with exact text from search results' do
+          select2 'PlayStation', css: '#single', exact_text: true
+          expect(page).to have_css '.select2-container span', text: 'PlayStation'
+        end
       end
 
       context 'when searching for an option within a block' do


### PR DESCRIPTION
Hi - not sure if this is an option you want, but I needed it for a project so thought I'd pass it along 🙂